### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/source/_themes/nginx/__init__.py
+++ b/source/_themes/nginx/__init__.py
@@ -36,7 +36,7 @@ def create_sitemap(app, exception):
         return
 
     filename = app.outdir + "/sitemap.xml"
-    print("Generating sitemap.xml in %s" % filename)
+    print("Generating sitemap.xml in {0!s}".format(filename))
 
     root = ET.Element("urlset")
     root.set("xmlns", "http://www.sitemaps.org/schemas/sitemap/0.9")


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:nginx-wiki?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:nginx-wiki?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
